### PR TITLE
送信ボタンから次の画面にテキストを送信

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation 'androidx.core:core-ktx:1.0.2'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".DisplayMessageActivity"
+            android:parentActivityName=".MainActivity">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/bloominapp/DisplayMessageActivity.kt
+++ b/app/src/main/java/com/example/bloominapp/DisplayMessageActivity.kt
@@ -1,0 +1,20 @@
+package com.example.bloominapp
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.widget.TextView
+
+class DisplayMessageActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_display_message)
+
+        // Activity開始時にIntentを取得し、文字列をセットする
+        val intent: Intent = getIntent()
+        val message: String = intent.getStringExtra(MainActivity().EXTRA_MESSAGE)
+        val textView: TextView = findViewById(R.id.textView)
+        textView.setText(message)
+    }
+}

--- a/app/src/main/java/com/example/bloominapp/MainActivity.kt
+++ b/app/src/main/java/com/example/bloominapp/MainActivity.kt
@@ -1,12 +1,25 @@
 package com.example.bloominapp
 
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
+import android.view.View
+import android.widget.EditText
 import android.os.Bundle
 
 class MainActivity : AppCompatActivity() {
+    val EXTRA_MESSAGE: String = "com.example.myfirstapp.MESSAGE"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+    }
+
+    /* Sendボタン押下時 */
+    fun sendMessage(view: View) {
+        val intent: Intent = Intent(this@MainActivity,DisplayMessageActivity::class.java)
+        val editText: EditText = findViewById(R.id.editText) as EditText
+        val message: String = editText.text.toString()
+        intent.putExtra(EXTRA_MESSAGE, message)
+        startActivity(intent)
     }
 }

--- a/app/src/main/res/layout/activity_display_message.xml
+++ b/app/src/main/res/layout/activity_display_message.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".DisplayMessageActivity">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="124dp"
+        android:layout_marginEnd="8dp"
+        android:text="TextView"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,6 +24,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"
+        android:onClick="sendMessage"
         android:text="@string/button_send"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/editText"


### PR DESCRIPTION
# 画面追加
前の画面から送信されたテキストを表示する画面
- DisplayMessageActivity.kt
- activity_display_message.xml

# 変更点
- Mainactivity.kt
sendMessage()を追加(テキストを読み取ってDisplayMassageActivity.ktに遷移する)
sendMessage()をactivity_main.xmlのボタンに設定
